### PR TITLE
Adding initContainers  for the sidecar container and Readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,10 @@ positioned to make those tradeoffs.
 ## Example
 
 Here is a working [example](example.yaml) which you can use to understand this
-approach.
+approach. After applying the manifest you can check it using:
+
+```
+kubectl port-forward deployment/demo-kubectl-sidecar 8080:80
+curl http://localhost:8080/this-pod-status.json
+curl http://localhost:8080/this-node-status.json
+```

--- a/example.yaml
+++ b/example.yaml
@@ -91,8 +91,10 @@ spec:
         - mountPath: /usr/share/nginx/html
           name: content
           readOnly: true
+      initContainers:
       - name: sidecar
         image: thockin/kubectl-sidecar:v1.29.2-1
+        restartPolicy: Always
         env:
           - name: MYPOD
             valueFrom:


### PR DESCRIPTION
Since Kubernets 1.29 the initContainers: restartPolicy: Always is in beta which is for the sidecr containers. Since this repo shows great demonstration of sidecar use case so its better to use the initContainers for this with restartPolicy: ALways. 

Also added commands to check in the Readme for accessing the pod and node status. 